### PR TITLE
Add manual playback controls and static waterfall rendering

### DIFF
--- a/frontend/components/PlaybackBar.tsx
+++ b/frontend/components/PlaybackBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PlaybackTick, createPlaybackSocket } from '../lib/api';
 
@@ -9,20 +9,80 @@ export interface PlaybackBarProps {
   onTick?: (tick: PlaybackTick) => void;
 }
 
+type ConnectionState = 'idle' | 'connecting' | 'streaming' | 'error';
+
 export function PlaybackBar({ bandId, windowSeconds = 10, fps = 4, onTick }: PlaybackBarProps) {
   const [tick, setTick] = useState<PlaybackTick | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [connectionState, setConnectionState] = useState<ConnectionState>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isPlaying) {
+      return undefined;
+    }
+
+    setErrorMessage(null);
+    setConnectionState('connecting');
+
     const socket = createPlaybackSocket(bandId, { window_s: windowSeconds, fps });
+    let isActive = true;
+
+    socket.onopen = () => {
+      if (!isActive) return;
+      setConnectionState('streaming');
+    };
+
     socket.onmessage = (event) => {
+      if (!isActive) return;
       const payload = JSON.parse(event.data) as PlaybackTick;
       setTick(payload);
+      setConnectionState('streaming');
       onTick?.(payload);
     };
-    return () => {
-      socket.close();
+
+    socket.onerror = () => {
+      if (!isActive) return;
+      setConnectionState('error');
+      setErrorMessage('Playback connection failed.');
     };
-  }, [bandId, windowSeconds, fps, onTick]);
+
+    socket.onclose = () => {
+      if (!isActive) return;
+      setConnectionState('error');
+      setErrorMessage('Playback disconnected unexpectedly.');
+    };
+
+    return () => {
+      isActive = false;
+      socket.close();
+      setConnectionState('idle');
+    };
+  }, [bandId, windowSeconds, fps, isPlaying, onTick]);
+
+  const togglePlayback = useCallback(() => {
+    setIsPlaying((value) => !value);
+    setErrorMessage(null);
+  }, []);
+
+  const statusText = useMemo(() => {
+    if (connectionState === 'error') {
+      return errorMessage ?? 'Playback error.';
+    }
+    if (!isPlaying) {
+      if (tick) {
+        return `Paused at ${tick.t0.toFixed(2)}s → ${tick.t1.toFixed(2)}s.`;
+      }
+      return 'Playback paused. Press play to stream new data.';
+    }
+    if (connectionState === 'connecting') {
+      return 'Connecting…';
+    }
+    if (!tick) {
+      return 'Waiting for playback data…';
+    }
+    return `Window: ${tick.t0.toFixed(2)}s → ${tick.t1.toFixed(2)}s | Cursor UNIX: ${tick.cursor_unix.toFixed(2)}`;
+  }, [connectionState, errorMessage, isPlaying, tick]);
 
   return (
     <div
@@ -37,13 +97,26 @@ export function PlaybackBar({ bandId, windowSeconds = 10, fps = 4, onTick }: Pla
       }}
     >
       <strong>Playback</strong>
-      {tick ? (
-        <span>
-          Window: {tick.t0.toFixed(2)}s → {tick.t1.toFixed(2)}s &nbsp;|&nbsp; Cursor UNIX: {tick.cursor_unix.toFixed(2)}
-        </span>
-      ) : (
-        <span>Waiting for server…</span>
-      )}
+      <button
+        type="button"
+        onClick={togglePlayback}
+        style={{
+          appearance: 'none',
+          border: '1px solid rgba(255,255,255,0.2)',
+          background: isPlaying ? '#ff8c42' : '#2a3144',
+          color: '#fff',
+          padding: '0.35rem 0.85rem',
+          borderRadius: '999px',
+          cursor: 'pointer',
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em'
+        }}
+        aria-pressed={isPlaying}
+      >
+        {isPlaying ? 'Pause' : 'Play'}
+      </button>
+      <span style={{ fontSize: '0.85rem', opacity: 0.9 }}>{statusText}</span>
     </div>
   );
 }

--- a/frontend/components/Waterfall.tsx
+++ b/frontend/components/Waterfall.tsx
@@ -1,7 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import DeckGL from '@deck.gl/react';
-import { BitmapLayer } from '@deck.gl/layers';
-import { OrthographicView } from '@deck.gl/core';
+import { useEffect, useMemo, useState } from 'react';
 
 import { getWaterfallTile } from '../lib/api';
 
@@ -17,114 +14,145 @@ export interface WaterfallProps {
 
 interface TileState {
   url: string;
-  bounds: [number, number, number, number];
+  freqStart: number;
+  freqEnd: number;
+  timeStart: number;
+  timeEnd: number;
 }
 
 export function Waterfall({ bandId, f0, f1, t0, t1, maxw = 1600, maxt = 600 }: WaterfallProps) {
   const [tile, setTile] = useState<TileState | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [containerSize, setContainerSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
-  const [viewState, setViewState] = useState<{ target: [number, number, number]; zoom: number }>({ target: [0, 0, 0], zoom: 0 });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    async function load() {
-      const { blob, headers } = await getWaterfallTile(bandId, {
-        f0,
-        f1,
-        t0,
-        t1,
-        maxw,
-        maxt,
-        fmt: 'png'
-      });
-      if (cancelled) return;
-      const url = URL.createObjectURL(blob);
-      const freqStart = Number(headers.get('X-Freq-Start') ?? f0 ?? 0);
-      const freqEnd = Number(headers.get('X-Freq-End') ?? f1 ?? freqStart + 1);
-      const timeStart = Number(headers.get('X-Time-Start') ?? t0 ?? 0);
-      const timeEnd = Number(headers.get('X-Time-End') ?? t1 ?? timeStart + 1);
-      setTile((current) => {
-        if (current) {
-          URL.revokeObjectURL(current.url);
-        }
-        return { url, bounds: [freqStart, timeStart, freqEnd, timeEnd] };
-      });
-    }
-    load();
+    let objectUrl: string | null = null;
+
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const { blob, headers } = await getWaterfallTile(bandId, {
+          f0,
+          f1,
+          t0,
+          t1,
+          maxw,
+          maxt,
+          fmt: 'png'
+        });
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        const freqStart = Number(headers.get('X-Freq-Start') ?? f0 ?? 0);
+        const freqEnd = Number(headers.get('X-Freq-End') ?? f1 ?? freqStart + 1);
+        const timeStart = Number(headers.get('X-Time-Start') ?? t0 ?? 0);
+        const timeEnd = Number(headers.get('X-Time-End') ?? t1 ?? timeStart + 1);
+        setTile((current) => {
+          if (current) {
+            URL.revokeObjectURL(current.url);
+          }
+          return {
+            url: objectUrl as string,
+            freqStart,
+            freqEnd,
+            timeStart,
+            timeEnd
+          };
+        });
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Failed to load waterfall', err);
+        setTile((current) => {
+          if (current) {
+            URL.revokeObjectURL(current.url);
+          }
+          return null;
+        });
+        setError('Unable to load waterfall image.');
+        setLoading(false);
+      }
+    })();
+
     return () => {
       cancelled = true;
-      setTile((current) => {
-        if (current) {
-          URL.revokeObjectURL(current.url);
-        }
-        return null;
-      });
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
     };
   }, [bandId, f0, f1, t0, t1, maxw, maxt]);
 
-  // Observe container size for fitting
-  useEffect(() => {
-    if (!containerRef.current) return;
-    const el = containerRef.current;
-    const ro = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const cr = entry.contentRect;
-        setContainerSize({ width: cr.width, height: cr.height });
-      }
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
-  // Fit-to-bounds when a new tile or size arrives
-  useEffect(() => {
-    if (!tile || containerSize.width <= 0 || containerSize.height <= 0) return;
-    const [fx0, ty0, fx1, ty1] = tile.bounds;
-    const worldW = Math.max(1e-6, Math.abs(fx1 - fx0));
-    const worldH = Math.max(1e-6, Math.abs(ty1 - ty0));
-    const scaleX = containerSize.width / worldW;
-    const scaleY = containerSize.height / worldH;
-    const scale = Math.max(1e-9, Math.min(scaleX, scaleY));
-    const zoom = Math.log2(scale);
-    const cx = fx0 + worldW / 2;
-    const cy = ty0 + worldH / 2;
-    setViewState({ target: [cx, cy, 0], zoom });
-  }, [tile, containerSize]);
-
-  const layer = useMemo(() => {
+  const axisText = useMemo(() => {
     if (!tile) return null;
-    return new BitmapLayer({
-      id: 'waterfall-bitmap',
-      image: tile.url,
-      bounds: tile.bounds,
-      desaturate: 0,
-      opacity: 1
-    });
+    const freq = `${tile.freqStart.toFixed(2)} MHz → ${tile.freqEnd.toFixed(2)} MHz`;
+    const time = `${tile.timeStart.toFixed(2)} s → ${tile.timeEnd.toFixed(2)} s`;
+    return { freq, time };
   }, [tile]);
 
   return (
-    <div ref={containerRef} style={{ position: 'relative' }}>
-      <DeckGL
-        views={new OrthographicView({ flipY: true })}
-        controller={{ dragPan: true, dragRotate: false, scrollZoom: true, doubleClickZoom: true }}
-        viewState={viewState}
-        onViewStateChange={(e) => setViewState(e.viewState as any)}
-        style={{ width: '100%', height: '400px' }}
-        layers={layer ? [layer] : []}
-      />
-      <div
-        style={{
-          position: 'absolute',
-          right: 16,
-          top: 16,
-          width: 12,
-          height: 160,
-          background: 'linear-gradient(180deg, #fffbcc 0%, #1a1e2b 100%)',
-          borderRadius: 6,
-          border: '1px solid rgba(255,255,255,0.3)'
-        }}
-      />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        background: '#0f1320',
+        borderRadius: '0.75rem',
+        padding: '1rem',
+        border: '1px solid rgba(255,255,255,0.08)'
+      }}
+    >
+      <div style={{ position: 'relative', minHeight: 280 }}>
+        {tile && !loading && !error ? (
+          <img
+            src={tile.url}
+            alt="Waterfall heatmap"
+            style={{
+              display: 'block',
+              width: '100%',
+              height: 'auto',
+              borderRadius: '0.5rem'
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '100%',
+              height: 280,
+              borderRadius: '0.5rem',
+              background: 'rgba(26,30,43,0.6)',
+              border: '1px dashed rgba(255,255,255,0.1)',
+              color: 'rgba(255,255,255,0.6)'
+            }}
+          >
+            {loading ? 'Loading waterfall…' : error ?? 'No waterfall available.'}
+          </div>
+        )}
+        {tile ? (
+          <div
+            style={{
+              position: 'absolute',
+              right: 16,
+              top: 16,
+              width: 12,
+              height: 160,
+              background: 'linear-gradient(180deg, #fffbcc 0%, #1a1e2b 100%)',
+              borderRadius: 6,
+              border: '1px solid rgba(255,255,255,0.3)'
+            }}
+          />
+        ) : null}
+      </div>
+      {axisText ? (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem', fontSize: '0.85rem', opacity: 0.85 }}>
+          <span><strong>Frequency:</strong> {axisText.freq}</span>
+          <span><strong>Time:</strong> {axisText.time}</span>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add play/pause controls to the playback bar and open the websocket only when streaming
- show connection status messaging so playback stays paused until the user opts in
- render waterfall tiles as static images with metadata and graceful loading/error states

## Testing
- not run (interactive eslint setup required)

------
https://chatgpt.com/codex/tasks/task_e_68e4e54505e88324849418da764d47eb